### PR TITLE
Uses psutils to get the cpu utilization

### DIFF
--- a/demo-reporter/cpu-utilization_mac.c
+++ b/demo-reporter/cpu-utilization_mac.c
@@ -1,0 +1,111 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#include <sys/time.h>
+#include <mach/mach.h>
+#include <mach/mach_host.h>
+#include <unistd.h>
+
+void loop_utilization(unsigned int msleep_time) {
+    processor_info_array_t cpuInfo = NULL, prevCpuInfo = NULL;
+    mach_msg_type_number_t numCpuInfo, numPrevCpuInfo;
+
+    while(1){
+        natural_t numCPUsU = 0U;
+        kern_return_t err = host_processor_info(mach_host_self(), PROCESSOR_CPU_LOAD_INFO, &numCPUsU, &cpuInfo, &numCpuInfo);
+
+        if (err == KERN_SUCCESS) {
+
+            float ut_total = 0U;
+            struct timeval now;
+
+            for (unsigned i = 0; i < numCPUsU; ++i) {
+                float inUse, total;
+                if (prevCpuInfo) {
+                    inUse = ((cpuInfo[(CPU_STATE_MAX * i) + CPU_STATE_USER] - prevCpuInfo[(CPU_STATE_MAX * i) + CPU_STATE_USER]) +
+                            (cpuInfo[(CPU_STATE_MAX * i) + CPU_STATE_SYSTEM] - prevCpuInfo[(CPU_STATE_MAX * i) + CPU_STATE_SYSTEM]) +
+                            (cpuInfo[(CPU_STATE_MAX * i) + CPU_STATE_NICE] - prevCpuInfo[(CPU_STATE_MAX * i) + CPU_STATE_NICE]));
+                    total = inUse + (cpuInfo[(CPU_STATE_MAX * i) + CPU_STATE_IDLE] - prevCpuInfo[(CPU_STATE_MAX * i) + CPU_STATE_IDLE]);
+                } else {
+                    inUse = cpuInfo[(CPU_STATE_MAX * i) + CPU_STATE_USER] + cpuInfo[(CPU_STATE_MAX * i) + CPU_STATE_SYSTEM] + cpuInfo[(CPU_STATE_MAX * i) + CPU_STATE_NICE];
+                    total = inUse + cpuInfo[(CPU_STATE_MAX * i) + CPU_STATE_IDLE];
+                }
+                ut_total = ut_total + (inUse / total);
+            }
+
+            gettimeofday(&now, NULL);
+            printf("%ld%06i %i\n", now.tv_sec, now.tv_usec, (int)(ut_total * 100 / numCPUsU));
+
+            if (prevCpuInfo) {
+                size_t prevCpuInfoSize = sizeof(integer_t) * numPrevCpuInfo;
+                vm_deallocate(mach_task_self(), (vm_address_t)prevCpuInfo, prevCpuInfoSize);
+            }
+
+            prevCpuInfo = cpuInfo;
+            numPrevCpuInfo = numCpuInfo;
+
+            cpuInfo = NULL;
+            numCpuInfo = 0U;
+        } else {
+            fprintf(stderr, "Error: %s\n", mach_error_string(err));
+        }
+
+    usleep(msleep_time*1000);
+    }
+}
+
+
+static int check_system() {
+    processor_info_array_t cpuInfo = NULL;
+    mach_msg_type_number_t numCpuInfo;
+    natural_t numCPUsU = 0U;
+
+    kern_return_t err = host_processor_info(mach_host_self(), PROCESSOR_CPU_LOAD_INFO, &numCPUsU, &cpuInfo, &numCpuInfo);
+
+    if (err == KERN_SUCCESS) {
+        if (numCPUsU > 0){
+            return 0;
+        }else{
+            fprintf(stderr, "The call was successful but the data is wrong.");
+            return 1;
+        }
+    }else{
+        fprintf(stderr, "There was an error getting CPU info: %s\n", mach_error_string(err));
+        return err;
+    }
+}
+
+int main(int argc, char **argv) {
+
+    int c;
+    unsigned int msleep_time=1000;
+
+    setvbuf(stdout, NULL, _IONBF, 0);
+
+    while ((c = getopt (argc, argv, "i:hc")) != -1) {
+        switch (c) {
+        case 'h':
+            printf("Usage: %s [-i msleep_time] [-h]\n\n",argv[0]);
+            printf("\t-h      : displays this help\n");
+            printf("\t-i      : specifies the milliseconds sleep time that will be slept between measurements\n");
+            printf("\t-c      : check system and exit\n\n");
+            exit(0);
+        case 'i':
+            msleep_time = atoi(optarg);
+            if (msleep_time < 50){
+                fprintf(stderr,"A value of %i is to small. Results will include 0s as the kernel does not update as fast.\n",msleep_time);
+            }
+            break;
+        case 'c':
+            exit(check_system());
+        default:
+            fprintf(stderr,"Unknown option %c\n",c);
+            exit(-1);
+        }
+    }
+
+    loop_utilization(msleep_time);
+
+    return 0;
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ pandas==2.2.0
 scipy==1.12.0
 scikit-learn==1.4.0
 xgboost==2.0.3
+psutil==5.9.8
+pyarrow==15.0.0

--- a/xgb.py
+++ b/xgb.py
@@ -3,6 +3,7 @@
 import sys
 import os
 import time
+import platform
 import pandas as pd
 import numpy as np
 from xgboost import XGBRegressor
@@ -109,6 +110,17 @@ if __name__ == '__main__':
     parser.add_argument('--interval', type=float, help='Interval in seconds if autoinput is used.', default=1.0)
 
     args = parser.parse_args()
+
+    if platform.system() == 'Darwin' and args.autoinput and args.interval < 0.5:
+        print('''
+                Under MacOS the internal values are updated every 0.5 seconds by the kernel if you use the host_statistics call.
+                There is another way to get the cpu utilization by using the host_processor_info call.
+                Psutils uses host_statistics so intervals under 0.5 are not sensible. We have opened a discussion here:
+                https://github.com/giampaolo/psutil/issues/2368
+                If you want a higher resolution you can use the cpu_utilization_mac.c file in the demo-reporter folder.
+              ''')
+        sys.exit(1)
+
 
     Z = pd.DataFrame.from_dict({
         'HW_CPUFreq' : [args.cpu_freq],

--- a/xgb.py
+++ b/xgb.py
@@ -147,7 +147,7 @@ if __name__ == '__main__':
         import psutil
         def cpu_utalisation():
             while True:
-                yield str(psutil.cpu_percent(args.interval))
+                yield str(psutil.cpu_percent(args.interval) * 100)
 
         input_source = cpu_utalisation()
 

--- a/xgb.py
+++ b/xgb.py
@@ -145,19 +145,23 @@ if __name__ == '__main__':
     input_source = sys.stdin
     if args.auto:
         import psutil
-        def cpu_utalisation():
+        def cpu_utilization():
             while True:
-                yield str(psutil.cpu_percent(args.interval) * 100 / psutil.cpu_count())
+                cpu_util = psutil.cpu_percent(args.interval)
+                yield str(cpu_util)
 
-        input_source = cpu_utalisation()
+        input_source = cpu_utilization()
 
 
-    if args.energy:
-        current_time = time.time_ns()
-        for line in input_source:
-            print(interpolated_predictions[float(line.strip())] * args.vhost_ratio * \
+    for line in input_source:
+        utilization = float(line.strip())
+        if utilization < 0 or utilization > 100:
+            raise ValueError("Utilization can not be over 100%. If you have multiple CPU cores please divide by cpu count.")
+
+        if args.energy:
+            current_time = time.time_ns()
+            print(interpolated_predictions[utilization] * args.vhost_ratio * \
                 (time.time_ns() - current_time) / 1_000_000_000, flush=True)
             current_time = time.time_ns()
-    else:
-        for line in input_source:
-            print(interpolated_predictions[float(line.strip())] * args.vhost_ratio, flush=True)
+        else:
+                print(interpolated_predictions[utilization] * args.vhost_ratio, flush=True)

--- a/xgb.py
+++ b/xgb.py
@@ -147,7 +147,7 @@ if __name__ == '__main__':
         import psutil
         def cpu_utalisation():
             while True:
-                yield str(psutil.cpu_percent(args.interval) * 100)
+                yield str(psutil.cpu_percent(args.interval) * 100 / psutil.cpu_count())
 
         input_source = cpu_utalisation()
 
@@ -156,9 +156,8 @@ if __name__ == '__main__':
         current_time = time.time_ns()
         for line in input_source:
             print(interpolated_predictions[float(line.strip())] * args.vhost_ratio * \
-                (time.time_ns() - current_time) / 1_000_000_000
-            )
+                (time.time_ns() - current_time) / 1_000_000_000, flush=True)
             current_time = time.time_ns()
     else:
         for line in input_source:
-            print(interpolated_predictions[float(line.strip())] * args.vhost_ratio)
+            print(interpolated_predictions[float(line.strip())] * args.vhost_ratio, flush=True)

--- a/xgb.py
+++ b/xgb.py
@@ -105,8 +105,8 @@ if __name__ == '__main__':
         This is achieved by multiplying the interval between inputs with the estimated wattage'
     )
 
-    parser.add_argument('--auto', action='store_true', help='Will get the CPU utilization through psutil.')
-    parser.add_argument('--interval', type=float, help='Interval in seconds if auto is used.', default=1.0)
+    parser.add_argument('--autoinput', action='store_true', help='Will get the CPU utilization through psutil.')
+    parser.add_argument('--interval', type=float, help='Interval in seconds if autoinput is used.', default=1.0)
 
     args = parser.parse_args()
 
@@ -143,7 +143,7 @@ if __name__ == '__main__':
     interpolated_predictions = interpolate_predictions(inferred_predictions)
 
     input_source = sys.stdin
-    if args.auto:
+    if args.autoinput:
         import psutil
         def cpu_utilization():
             while True:


### PR DESCRIPTION
While working on the cloud machine script it was quite annoying to have to keep the c script around. It looks like the c metrics provider and the psutils implementation give similar results. Also I can't see much difference on overhead on my development machine.

I think this will also make the ci scripts easier as we don't need to compile the metric provider all the time. I have the feeling I am missing something though. Why didn't we do this from the beginning? 